### PR TITLE
Add Dockerfile, Makefile and helm-chart for migration tool

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -1,0 +1,22 @@
+# Builder image
+FROM golang:1.16 as builder
+
+# Workaround because migration tool is private repo
+ARG SSH_PRIVATE_KEY
+RUN mkdir /root/.ssh/ && \
+    echo "${SSH_PRIVATE_KEY}" > /root/.ssh/id_rsa && \
+    chmod 600 /root/.ssh/id_rsa && \
+    ssh-keyscan -t rsa -H github.com > ~/.ssh/known_hosts
+
+ENV GOPRIVATE=github.com/SAP/sap-btp-service-operator-migration
+RUN git config --global url.git@github.com:.insteadOf https://github.com/
+
+RUN CGO_ENABLED=0 go install github.com/SAP/sap-btp-service-operator-migration@v0.1.0
+
+# Run image
+FROM gcr.io/distroless/static:latest
+
+COPY --from=builder /etc/ssl/certs /etc/ssl/certs
+COPY --from=builder /go/bin/sap-btp-service-operator-migration /bin/sap-btp-service-operator-migration
+
+ENTRYPOINT ["sap-btp-service-operator-migration"]

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -11,7 +11,11 @@ RUN mkdir /root/.ssh/ && \
 ENV GOPRIVATE=github.com/SAP/sap-btp-service-operator-migration
 RUN git config --global url.git@github.com:.insteadOf https://github.com/
 
-RUN CGO_ENABLED=0 go install github.com/SAP/sap-btp-service-operator-migration@v0.1.0
+# TODO: sent changes to upstream
+# https://github.com/wozniakjan/sap-btp-service-operator-migration/pull/new/allow_in_cluster
+RUN git clone --branch=allow_in_cluster --depth=1 https://github.com/wozniakjan/sap-btp-service-operator-migration && \
+    cd sap-btp-service-operator-migration && \
+    CGO_ENABLED=0 go build -o /go/bin/sap-btp-service-operator-migration main.go
 
 # Run image
 FROM gcr.io/distroless/static:latest

--- a/deploy/Makefile
+++ b/deploy/Makefile
@@ -1,0 +1,9 @@
+IMG ?= eu.gcr.io/sap-se-cx-gopher/sap-btp-service-operator-migration:v0.1.0
+
+.PHONY: build-image
+build-image:
+	docker build --build-arg SSH_PRIVATE_KEY="$$SSH_PRIVATE_KEY" . -t ${IMG}
+
+.PHONY: build-image
+push-image:
+	docker push ${IMG}

--- a/deploy/chart/Chart.yaml
+++ b/deploy/chart/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: sap-btp-operator-migration
+description: A helm chart for SAP BTP Service operator migration tool
+appVersion: v0.1.0
+version: v0.0.1

--- a/deploy/chart/templates/clusterrole.yaml
+++ b/deploy/chart/templates/clusterrole.yaml
@@ -1,0 +1,40 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: sap-btp-operator-migration
+rules:
+- apiGroups:
+  - ""
+  resources:
+  # this tool changes owner reference of the secret to prevent
+  # cascade delete when service catalog servicebindings is deleted
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  # needs to get sap-btp-operator ConfigMap 
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - services.cloud.sap.com
+  - servicecatalog.k8s.io
+  resources:
+  - servicebindings
+  - serviceinstances
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete

--- a/deploy/chart/templates/clusterrolebinding.yaml
+++ b/deploy/chart/templates/clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: sap-btp-operator-migration
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: sap-btp-operator-migration
+subjects:
+  - kind: ServiceAccount
+    name: sap-btp-operator-migration
+    namespace: {{.Release.Namespace}}

--- a/deploy/chart/templates/job.yaml
+++ b/deploy/chart/templates/job.yaml
@@ -1,0 +1,23 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: sap-btp-operator-migration
+  namespace: {{.Release.Namespace}}
+spec:
+  backoffLimit: 6
+  completions: 1
+  parallelism: 1
+  template:
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
+    spec:
+      serviceAccountName: sap-btp-operator-migration
+      restartPolicy: Never
+      containers:
+        - name: migration
+          command:
+            - sap-btp-service-operator-migration
+            - run
+          image: {{.Values.image.repository}}:{{.Values.image.tag}}
+          imagePullPolicy: Always

--- a/deploy/chart/templates/serviceaccount.yaml
+++ b/deploy/chart/templates/serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: sap-btp-operator-migration
+  namespace: {{.Release.Namespace}}

--- a/deploy/chart/values.yaml
+++ b/deploy/chart/values.yaml
@@ -1,0 +1,3 @@
+image:
+  repository: eu.gcr.io/sap-se-cx-gopher/sap-btp-service-operator-migration
+  tag: v0.1.0


### PR DESCRIPTION
This PR contains a way to build migration tool as a container and deployable helm-chart to go along with https://github.com/kyma-incubator/sap-btp-service-operator/pull/1

sample execution:
```
$ k logs sap-btp-operator-migration-qvlws
W0726 15:48:06.778712       1 client_config.go:614] Neither --kubeconfig nor --master was specified.  Using the inClusterConfig.  This might not work.
Migrator initialized with cluster ID 'd4b9a2e1-a2cf-4209-8c49-b438e16f087d'
*** Fetched 1 instances from SM
*** Fetched 0 bindings from SM
*** Fetched 3 svcat instances from cluster
*** Fetched 2 svcat bindings from cluster
*** Preparing resources
svcat instance name 'service-manager-distant-pleasure' id 'f2f5a881-e751-4424-ae70-01ebb3102ba8' (service-manager-distant-pleasure) not found in SM, skipping it...
svcat instance name 'service-manager-undefined-presentation' id 'eabcdc96-afdb-4641-894a-cdeeefc5044d' (service-manager-undefined-presentation) not found in SM, skipping it...
svcat instance name 'uaa-issuer' id '57709772-b2b1-486e-b332-b55f70aadbb6' (uaa-issuer) not found in SM, skipping it...
svcat binding name 'hopeful-williams' id 'c871ae68-fb66-40d0-8917-930755e047cf' (hopeful-williams) not found in SM, skipping it...
svcat binding name 'uaa-issuer-secret' id 'ab7eb2fe-981d-49ac-88d8-31494a9e65e5' (uaa-issuer-secret) not found in SM, skipping it...
no svcat instances or bindings found for migration
```