### PR TITLE
Skip deleting resources of missing CRDs

### DIFF
--- a/main.go
+++ b/main.go
@@ -2,15 +2,17 @@ package main
 
 import (
 	"io/ioutil"
-	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	"log"
 	"os"
 	"path"
 	"time"
+
+	_ "k8s.io/client-go/plugin/pkg/client/auth"
 )
 
 const CommandSBUPrepare = "sbu-prepare"
 const CommandFinalClean = "final-clean"
+
 /*
 The application expects environment varialbe "KUBECONFIG" to be set, then uninstalls Service Catalog and removes all SC resources.
 */
@@ -95,7 +97,7 @@ func main() {
 		}
 
 		log.Println("Deleting CRDs")
-		err = cleaner.RemnoveCRDs()
+		err = cleaner.RemoveCRDs()
 		if err != nil {
 			panic(err)
 		}


### PR DESCRIPTION
In order to improve on the idempotency, if some previous execution managed to delete a certain CRD, we should allow the subsequent executions to not fail and execute as far as possible by accepting and logging missing CRD errors.

example execution when I deleted a `ClusterServiceBroker` before running the removal tool.
```
$ go run ./main.go ./cleaner.go
2021/09/01 16:22:28 Using kubeconfig file: /home/wozy/tmp/sap/keb/shoot--kyma-dev--e83bdcc.yaml
2021/09/01 16:22:28 Removing Service Catalog release
2021/09/01 16:22:28 Looking for service-catalog release...
2021/09/01 16:22:29 service-catalog release not found, nothing to do
2021/09/01 16:22:29 Removing Helm Broker release
2021/09/01 16:22:29 Looking for helm-broker release...
2021/09/01 16:22:29 helm-broker release not found, nothing to do
2021/09/01 16:22:39 Removing finalizers
2021/09/01 16:22:41 ServiceBindingList kyma-system/uaa-issuer-secret: finalizers removed
2021/09/01 16:22:41 ServiceInstanceList kyma-system/uaa-issuer: finalizers removed
2021/09/01 16:22:42 CRD for GVK servicecatalog.k8s.io/v1beta1, Kind=ClusterServiceBrokerList not found, skipping finalizer removal
2021/09/01 16:22:42 UsageKind compass-system/deployment: finalizers removed
2021/09/01 16:22:42 UsageKind compass-system/serverless-function: finalizers removed
...
```