### PR TITLE
Pass job namespace to migrator

### DIFF
--- a/deploy/chart/templates/job.yaml
+++ b/deploy/chart/templates/job.yaml
@@ -20,3 +20,8 @@ spec:
 #          command: ["cleaner"]
           image: {{.Values.image.repository}}:{{.Values.image.tag}}
           imagePullPolicy: Always
+          env:
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace

--- a/deploy/run.sh
+++ b/deploy/run.sh
@@ -5,6 +5,6 @@ set -e
 
 cleaner sbu-prepare
 
-sap-btp-service-operator-migration run
+sap-btp-service-operator-migration -namespace ${POD_NAMESPACE} run
 
 cleaner final-clean


### PR DESCRIPTION
the namespace where btp-operator is installed was recently changed from `sap-btp-operator` to `kyma-system`. This needs to be propagated to the migration script as well

https://github.com/SAP/sap-btp-service-operator-migration/blob/0fd90f1e878f1518c989e5af9832bdd13f45cb6a/cmd/root.go#L55